### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/752/351/101752351.geojson
+++ b/data/101/752/351/101752351.geojson
@@ -214,6 +214,9 @@
         "wk:page":"\u017burrieq"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b94ece1dbbafe07281e3dbaa3eefd56",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":101752351,
-    "wof:lastmodified":1566612068,
+    "wof:lastmodified":1582316830,
     "wof:name":"Zurrieq",
     "wof:parent_id":85686717,
     "wof:placetype":"locality",

--- a/data/101/752/355/101752355.geojson
+++ b/data/101/752/355/101752355.geojson
@@ -189,6 +189,9 @@
         "qs_pg:id":1036639
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a0a1f025b96636c36d6f6e4016de5cd5",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101752355,
-    "wof:lastmodified":1566612064,
+    "wof:lastmodified":1582316829,
     "wof:name":"Qrendi",
     "wof:parent_id":85686721,
     "wof:placetype":"locality",

--- a/data/101/752/357/101752357.geojson
+++ b/data/101/752/357/101752357.geojson
@@ -189,6 +189,9 @@
         "wd:id":"Q658903"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61cd8ffa39e2dc6eec4c24e4441d54c6",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101752357,
-    "wof:lastmodified":1566612068,
+    "wof:lastmodified":1582316830,
     "wof:name":"Safi",
     "wof:parent_id":85686727,
     "wof:placetype":"locality",

--- a/data/101/752/361/101752361.geojson
+++ b/data/101/752/361/101752361.geojson
@@ -199,6 +199,9 @@
         "qs_pg:id":1072698
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1d4faae6cf1859e5d364cf0d3c1a535",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":101752361,
-    "wof:lastmodified":1566612067,
+    "wof:lastmodified":1582316830,
     "wof:name":"Marsaxlokk",
     "wof:parent_id":85686743,
     "wof:placetype":"locality",

--- a/data/101/752/363/101752363.geojson
+++ b/data/101/752/363/101752363.geojson
@@ -186,6 +186,9 @@
         "qs_pg:id":278933
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d39e9f292f59bb5139aaa889a0d6cee",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":101752363,
-    "wof:lastmodified":1566612064,
+    "wof:lastmodified":1582316829,
     "wof:name":"Gudja",
     "wof:parent_id":85686747,
     "wof:placetype":"locality",

--- a/data/101/752/365/101752365.geojson
+++ b/data/101/752/365/101752365.geojson
@@ -202,6 +202,9 @@
         "wk:page":"G\u0127axaq"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e715084858bc8a7adcef38090df39a88",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":101752365,
-    "wof:lastmodified":1566612063,
+    "wof:lastmodified":1582316829,
     "wof:name":"Ghaxaq",
     "wof:parent_id":85686749,
     "wof:placetype":"locality",

--- a/data/101/752/369/101752369.geojson
+++ b/data/101/752/369/101752369.geojson
@@ -199,6 +199,9 @@
         "qs_pg:id":1055712
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"facdf7de36697259fcf567273c7053ae",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":101752369,
-    "wof:lastmodified":1566612068,
+    "wof:lastmodified":1582316830,
     "wof:name":"Dingli",
     "wof:parent_id":85686763,
     "wof:placetype":"locality",

--- a/data/101/752/375/101752375.geojson
+++ b/data/101/752/375/101752375.geojson
@@ -198,6 +198,9 @@
         "wd:id":"Q744001"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40e7fc4ecbd943ca7270455dde7c834a",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":101752375,
-    "wof:lastmodified":1566612071,
+    "wof:lastmodified":1582316830,
     "wof:name":"Tarxien",
     "wof:parent_id":85686771,
     "wof:placetype":"locality",

--- a/data/101/752/377/101752377.geojson
+++ b/data/101/752/377/101752377.geojson
@@ -273,6 +273,9 @@
         "qs_pg:id":1055708
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8eb2a521332cc3efb8d831ff3730de0b",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
         }
     ],
     "wof:id":101752377,
-    "wof:lastmodified":1566612066,
+    "wof:lastmodified":1582316830,
     "wof:name":"Fgura",
     "wof:parent_id":85686781,
     "wof:placetype":"locality",

--- a/data/101/752/379/101752379.geojson
+++ b/data/101/752/379/101752379.geojson
@@ -214,6 +214,9 @@
         "wk:page":"Marsaskala"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8432e724a51e57943bf2ba249e36339",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":101752379,
-    "wof:lastmodified":1566612066,
+    "wof:lastmodified":1582316829,
     "wof:name":"Marsaskala",
     "wof:parent_id":85686785,
     "wof:placetype":"locality",

--- a/data/101/752/383/101752383.geojson
+++ b/data/101/752/383/101752383.geojson
@@ -161,6 +161,9 @@
         "qs_pg:id":1036649
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a7505433efa35c00bb3841990589b2e",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101752383,
-    "wof:lastmodified":1566612066,
+    "wof:lastmodified":1582316829,
     "wof:name":"Marsa",
     "wof:parent_id":85686803,
     "wof:placetype":"locality",

--- a/data/101/752/391/101752391.geojson
+++ b/data/101/752/391/101752391.geojson
@@ -203,6 +203,9 @@
         "wk:page":"Paola, Malta"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71d333ce0bf46af50257865f8340d119",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":101752391,
-    "wof:lastmodified":1566612063,
+    "wof:lastmodified":1582316829,
     "wof:name":"Paola",
     "wof:parent_id":85686815,
     "wof:placetype":"locality",

--- a/data/101/752/393/101752393.geojson
+++ b/data/101/752/393/101752393.geojson
@@ -189,6 +189,9 @@
         "qs_pg:id":238256
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ecb6cb5f32988694708ca70c53cacb7",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101752393,
-    "wof:lastmodified":1566612069,
+    "wof:lastmodified":1582316830,
     "wof:name":"Mtarfa",
     "wof:parent_id":85686875,
     "wof:placetype":"locality",

--- a/data/101/752/397/101752397.geojson
+++ b/data/101/752/397/101752397.geojson
@@ -201,6 +201,9 @@
         "qs_pg:id":1055724
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29cd9ab722997397c196dcbdd6d7f846",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":101752397,
-    "wof:lastmodified":1566612064,
+    "wof:lastmodified":1582316829,
     "wof:name":"Santa Venera",
     "wof:parent_id":85686837,
     "wof:placetype":"locality",

--- a/data/101/752/401/101752401.geojson
+++ b/data/101/752/401/101752401.geojson
@@ -216,6 +216,9 @@
         "qs_pg:id":1036667
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61ddb4e321b0e195628bdf65808f878b",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         }
     ],
     "wof:id":101752401,
-    "wof:lastmodified":1566612065,
+    "wof:lastmodified":1582316829,
     "wof:name":"Attard",
     "wof:parent_id":85686851,
     "wof:placetype":"locality",

--- a/data/101/752/403/101752403.geojson
+++ b/data/101/752/403/101752403.geojson
@@ -196,6 +196,9 @@
         "qs_pg:id":278930
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fde8d4ffc1f3ff730de05546963b1b3",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":101752403,
-    "wof:lastmodified":1566612071,
+    "wof:lastmodified":1582316830,
     "wof:name":"Floriana",
     "wof:parent_id":85686855,
     "wof:placetype":"locality",

--- a/data/101/752/405/101752405.geojson
+++ b/data/101/752/405/101752405.geojson
@@ -189,6 +189,9 @@
         "wd:id":"Q789794"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a289729d8ced16b6a57cb814a3991e75",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101752405,
-    "wof:lastmodified":1566612070,
+    "wof:lastmodified":1582316830,
     "wof:name":"Balzan",
     "wof:parent_id":85686859,
     "wof:placetype":"locality",

--- a/data/101/752/409/101752409.geojson
+++ b/data/101/752/409/101752409.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Kalkara"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87d5c03c2be211eb7d75edbe88593a47",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         }
     ],
     "wof:id":101752409,
-    "wof:lastmodified":1566612066,
+    "wof:lastmodified":1582316829,
     "wof:name":"Kalkara",
     "wof:parent_id":85686863,
     "wof:placetype":"locality",

--- a/data/101/752/415/101752415.geojson
+++ b/data/101/752/415/101752415.geojson
@@ -183,6 +183,9 @@
         "qs_pg:id":1036652
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7715be05f5d78d44c89dfae9a65be077",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":101752415,
-    "wof:lastmodified":1566612065,
+    "wof:lastmodified":1582316829,
     "wof:name":"Lija",
     "wof:parent_id":85686871,
     "wof:placetype":"locality",

--- a/data/101/752/417/101752417.geojson
+++ b/data/101/752/417/101752417.geojson
@@ -236,6 +236,9 @@
         "wk:page":"Rabat, Malta"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7311fc32480536666b432c7bf2fd3bd2",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
         }
     ],
     "wof:id":101752417,
-    "wof:lastmodified":1566612069,
+    "wof:lastmodified":1582316830,
     "wof:name":"Rabat",
     "wof:parent_id":85686875,
     "wof:placetype":"locality",

--- a/data/101/752/419/101752419.geojson
+++ b/data/101/752/419/101752419.geojson
@@ -287,6 +287,9 @@
         "qs_pg:id":1078165
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4440578a1d6cfcab3923f446afcb690",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         }
     ],
     "wof:id":101752419,
-    "wof:lastmodified":1566612069,
+    "wof:lastmodified":1582316830,
     "wof:name":"Birkirkara",
     "wof:parent_id":85686879,
     "wof:placetype":"locality",

--- a/data/101/752/421/101752421.geojson
+++ b/data/101/752/421/101752421.geojson
@@ -204,6 +204,9 @@
         "qs_pg:id":1036644
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8ede2002e749ce0158d2f6078da911f",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":101752421,
-    "wof:lastmodified":1566612069,
+    "wof:lastmodified":1582316830,
     "wof:name":"Msida",
     "wof:parent_id":85686883,
     "wof:placetype":"locality",

--- a/data/101/752/423/101752423.geojson
+++ b/data/101/752/423/101752423.geojson
@@ -613,6 +613,9 @@
         85686889
     ],
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6b99ded49ba415228034a73ced1868e",
     "wof:hierarchy":[
         {
@@ -623,7 +626,7 @@
         }
     ],
     "wof:id":101752423,
-    "wof:lastmodified":1566612065,
+    "wof:lastmodified":1582316829,
     "wof:megacity":0,
     "wof:name":"Valletta",
     "wof:parent_id":85686889,

--- a/data/101/752/427/101752427.geojson
+++ b/data/101/752/427/101752427.geojson
@@ -190,6 +190,9 @@
         "qs_pg:id":1189353
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e03a09b74f5e508a37d7993a3b65832a",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":101752427,
-    "wof:lastmodified":1566612069,
+    "wof:lastmodified":1582316830,
     "wof:name":"Iklin",
     "wof:parent_id":85686897,
     "wof:placetype":"locality",

--- a/data/101/752/431/101752431.geojson
+++ b/data/101/752/431/101752431.geojson
@@ -243,6 +243,9 @@
         "qs_pg:id":278924
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2006af506b5d562d223d5304ba812e7",
     "wof:hierarchy":[
         {
@@ -253,7 +256,7 @@
         }
     ],
     "wof:id":101752431,
-    "wof:lastmodified":1566612066,
+    "wof:lastmodified":1582316829,
     "wof:name":"Sliema",
     "wof:parent_id":85686907,
     "wof:placetype":"locality",

--- a/data/101/752/433/101752433.geojson
+++ b/data/101/752/433/101752433.geojson
@@ -230,6 +230,9 @@
         "wk:page":"Mosta"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"443630a358e3707f5fc717989cce36f1",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         }
     ],
     "wof:id":101752433,
-    "wof:lastmodified":1566612070,
+    "wof:lastmodified":1582316830,
     "wof:name":"Mosta",
     "wof:parent_id":85686911,
     "wof:placetype":"locality",

--- a/data/101/752/437/101752437.geojson
+++ b/data/101/752/437/101752437.geojson
@@ -204,6 +204,9 @@
         "qs_pg:id":1036661
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5dc061cfd56f021a8924fcb2378aa3cd",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":101752437,
-    "wof:lastmodified":1566612065,
+    "wof:lastmodified":1582316829,
     "wof:name":"Swieqi",
     "wof:parent_id":85686925,
     "wof:placetype":"locality",

--- a/data/101/752/439/101752439.geojson
+++ b/data/101/752/439/101752439.geojson
@@ -187,6 +187,9 @@
         "wd:id":"Q775756"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16e0285666595e2e5d428574627e14fa",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":101752439,
-    "wof:lastmodified":1566612065,
+    "wof:lastmodified":1582316829,
     "wof:name":"Pembroke",
     "wof:parent_id":85686933,
     "wof:placetype":"locality",

--- a/data/101/752/441/101752441.geojson
+++ b/data/101/752/441/101752441.geojson
@@ -201,6 +201,9 @@
         "qs_pg:id":1036642
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"460c401ad69166cbd0c16cbedca9c8df",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":101752441,
-    "wof:lastmodified":1566612065,
+    "wof:lastmodified":1582316829,
     "wof:name":"Naxxar",
     "wof:parent_id":85686937,
     "wof:placetype":"locality",

--- a/data/101/752/445/101752445.geojson
+++ b/data/101/752/445/101752445.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Bu\u0121ibba"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aacffb3243da1a6d6bb86bdb51227b1b",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101752445,
-    "wof:lastmodified":1566612069,
+    "wof:lastmodified":1582316830,
     "wof:name":"Bugibba",
     "wof:parent_id":85686943,
     "wof:placetype":"locality",

--- a/data/101/752/449/101752449.geojson
+++ b/data/101/752/449/101752449.geojson
@@ -186,6 +186,9 @@
         "wd:id":"Q602037"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e41bc77e1c63b5b1a207f9246b7aed8",
     "wof:hierarchy":[
         {
@@ -196,7 +199,7 @@
         }
     ],
     "wof:id":101752449,
-    "wof:lastmodified":1566612064,
+    "wof:lastmodified":1582316829,
     "wof:name":"Sannat",
     "wof:parent_id":85686961,
     "wof:placetype":"locality",

--- a/data/101/752/453/101752453.geojson
+++ b/data/101/752/453/101752453.geojson
@@ -181,6 +181,9 @@
         "qs_pg:id":1078170
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0263f13bcb284853f26a85540378b114",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101752453,
-    "wof:lastmodified":1566612066,
+    "wof:lastmodified":1582316829,
     "wof:name":"Xewkija",
     "wof:parent_id":85686977,
     "wof:placetype":"locality",

--- a/data/101/752/459/101752459.geojson
+++ b/data/101/752/459/101752459.geojson
@@ -184,6 +184,9 @@
         "qs_pg:id":1036643
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e6f1a965a8c25f5b6db5591836578e79",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":101752459,
-    "wof:lastmodified":1566612070,
+    "wof:lastmodified":1582316830,
     "wof:name":"Nadur",
     "wof:parent_id":85686999,
     "wof:placetype":"locality",

--- a/data/101/752/467/101752467.geojson
+++ b/data/101/752/467/101752467.geojson
@@ -136,6 +136,9 @@
         "qs_pg:id":1036632
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"879b5da008662ccfb40b94c226425432",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":101752467,
-    "wof:lastmodified":1566612070,
+    "wof:lastmodified":1582316830,
     "wof:name":"Zebbug",
     "wof:parent_id":85687017,
     "wof:placetype":"locality",

--- a/data/101/752/469/101752469.geojson
+++ b/data/101/752/469/101752469.geojson
@@ -189,6 +189,9 @@
         "wd:id":"Q757225"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c07417bbc5034c2f188b181c8bb370bb",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101752469,
-    "wof:lastmodified":1561845143,
+    "wof:lastmodified":1582316830,
     "wof:name":"Bormla",
     "wof:parent_id":85687021,
     "wof:placetype":"locality",

--- a/data/101/756/769/101756769.geojson
+++ b/data/101/756/769/101756769.geojson
@@ -192,6 +192,9 @@
         "qs_pg:id":1036653
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c8530b14b46a7f60dcfbd626ed23abf",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":101756769,
-    "wof:lastmodified":1566612073,
+    "wof:lastmodified":1582316831,
     "wof:name":"Kirkop",
     "wof:parent_id":85686735,
     "wof:placetype":"locality",

--- a/data/101/756/771/101756771.geojson
+++ b/data/101/756/771/101756771.geojson
@@ -192,6 +192,9 @@
         "wd:id":"Q475585"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6eb47a27e46aca632090fcf800edadc2",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":101756771,
-    "wof:lastmodified":1561845144,
+    "wof:lastmodified":1582316830,
     "wof:name":"Luqa",
     "wof:parent_id":85686775,
     "wof:placetype":"locality",

--- a/data/101/756/777/101756777.geojson
+++ b/data/101/756/777/101756777.geojson
@@ -254,6 +254,9 @@
         "qs_pg:id":238253
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8c1ca2ee7c739237675ed04ced56316",
     "wof:hierarchy":[
         {
@@ -264,7 +267,7 @@
         }
     ],
     "wof:id":101756777,
-    "wof:lastmodified":1566612073,
+    "wof:lastmodified":1582316830,
     "wof:name":"Mdina",
     "wof:parent_id":85686799,
     "wof:placetype":"locality",

--- a/data/101/756/791/101756791.geojson
+++ b/data/101/756/791/101756791.geojson
@@ -199,6 +199,9 @@
         "wk:page":"San \u0120wann"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e41b1b58ce8c37a3db0128814086c83d",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":101756791,
-    "wof:lastmodified":1561845144,
+    "wof:lastmodified":1582316830,
     "wof:name":"San Gwann",
     "wof:parent_id":85686901,
     "wof:placetype":"locality",

--- a/data/101/805/249/101805249.geojson
+++ b/data/101/805/249/101805249.geojson
@@ -182,6 +182,9 @@
         "wk:page":"G\u0127arb"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b2918700e96df926fbdef5ebd1337f3b",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":101805249,
-    "wof:lastmodified":1561845144,
+    "wof:lastmodified":1582316830,
     "wof:name":"Gharb",
     "wof:parent_id":85687007,
     "wof:placetype":"locality",

--- a/data/101/846/465/101846465.geojson
+++ b/data/101/846/465/101846465.geojson
@@ -64,6 +64,9 @@
         "wd:id":"Q586551"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"62f06da272acafd6d855786793b04a75",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":101846465,
-    "wof:lastmodified":1566612074,
+    "wof:lastmodified":1582316831,
     "wof:name":"Bahrija",
     "wof:parent_id":85686929,
     "wof:placetype":"locality",

--- a/data/101/846/469/101846469.geojson
+++ b/data/101/846/469/101846469.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":302100
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8c2813236e5f822f6c6891d98ef8a19",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101846469,
-    "wof:lastmodified":1566612074,
+    "wof:lastmodified":1582316831,
     "wof:name":"Mgarr",
     "wof:parent_id":85686929,
     "wof:placetype":"locality",

--- a/data/101/846/479/101846479.geojson
+++ b/data/101/846/479/101846479.geojson
@@ -68,6 +68,9 @@
         "wk:page":"Manikata"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99f1812bd668ee0831c0ed9c15f53375",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":101846479,
-    "wof:lastmodified":1566612074,
+    "wof:lastmodified":1582316831,
     "wof:name":"Manikata",
     "wof:parent_id":85686947,
     "wof:placetype":"locality",

--- a/data/101/847/389/101847389.geojson
+++ b/data/101/847/389/101847389.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Xlendi"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9fcd22a8ddf3e080daf4a6d3de16a3c",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101847389,
-    "wof:lastmodified":1566612075,
+    "wof:lastmodified":1582316831,
     "wof:name":"Xlendi",
     "wof:parent_id":85686989,
     "wof:placetype":"locality",

--- a/data/101/848/915/101848915.geojson
+++ b/data/101/848/915/101848915.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":9
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"451f12b5e6453c1833e1d74f90d4fc50",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":101848915,
-    "wof:lastmodified":1566612074,
+    "wof:lastmodified":1582316831,
     "wof:name":"Delimara",
     "wof:parent_id":85686743,
     "wof:placetype":"locality",

--- a/data/101/848/917/101848917.geojson
+++ b/data/101/848/917/101848917.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":9
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6e3bec4c791eb1fbcae8b8e40f545c1",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101848917,
-    "wof:lastmodified":1566612075,
+    "wof:lastmodified":1582316831,
     "wof:name":"Zebbieh",
     "wof:parent_id":85686929,
     "wof:placetype":"locality",

--- a/data/101/848/919/101848919.geojson
+++ b/data/101/848/919/101848919.geojson
@@ -196,6 +196,9 @@
         "wd:id":"Q755979"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4659c46c4aa48699c945f844a3cfa9d9",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":101848919,
-    "wof:lastmodified":1566612074,
+    "wof:lastmodified":1582316831,
     "wof:name":"Mellieha",
     "wof:parent_id":1175612955,
     "wof:placetype":"locality",

--- a/data/101/850/019/101850019.geojson
+++ b/data/101/850/019/101850019.geojson
@@ -182,6 +182,10 @@
         "wk:page":"G\u0127asri"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d29be71422b5bf00216c3271703856e",
     "wof:hierarchy":[
         {
@@ -192,7 +196,7 @@
         }
     ],
     "wof:id":101850019,
-    "wof:lastmodified":1561845144,
+    "wof:lastmodified":1582316830,
     "wof:name":"Ghasri",
     "wof:parent_id":85687013,
     "wof:placetype":"locality",

--- a/data/101/874/849/101874849.geojson
+++ b/data/101/874/849/101874849.geojson
@@ -198,6 +198,10 @@
         "wk:page":"Mqabba"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"13ab9e9be2691c9efeedabf8b5e2f07f",
     "wof:hierarchy":[
         {
@@ -208,7 +212,7 @@
         }
     ],
     "wof:id":101874849,
-    "wof:lastmodified":1566612071,
+    "wof:lastmodified":1582316830,
     "wof:name":"Mqabba",
     "wof:parent_id":85686739,
     "wof:placetype":"locality",

--- a/data/101/874/851/101874851.geojson
+++ b/data/101/874/851/101874851.geojson
@@ -237,6 +237,10 @@
         "wk:page":"Qormi"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e23116ab22e68b9975897bb5d891fa7",
     "wof:hierarchy":[
         {
@@ -247,7 +251,7 @@
         }
     ],
     "wof:id":101874851,
-    "wof:lastmodified":1561845143,
+    "wof:lastmodified":1582316830,
     "wof:name":"Qormi",
     "wof:parent_id":85686805,
     "wof:placetype":"locality",

--- a/data/101/874/853/101874853.geojson
+++ b/data/101/874/853/101874853.geojson
@@ -233,6 +233,9 @@
         "wk:page":"Attard"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"052f068d7250176b2e88046048d20ff0",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
         }
     ],
     "wof:id":101874853,
-    "wof:lastmodified":1566612072,
+    "wof:lastmodified":1582316830,
     "wof:name":"Attard",
     "wof:parent_id":85686851,
     "wof:placetype":"locality",

--- a/data/101/874/855/101874855.geojson
+++ b/data/101/874/855/101874855.geojson
@@ -179,6 +179,10 @@
         "wd:id":"Q587462"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb0a289d8998b97158391aa35a722c2e",
     "wof:hierarchy":[
         {
@@ -189,7 +193,7 @@
         }
     ],
     "wof:id":101874855,
-    "wof:lastmodified":1566612072,
+    "wof:lastmodified":1582316830,
     "wof:name":"Munxar",
     "wof:parent_id":85686965,
     "wof:placetype":"locality",

--- a/data/101/874/857/101874857.geojson
+++ b/data/101/874/857/101874857.geojson
@@ -192,6 +192,10 @@
         "qs_pg:id":1036641
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4f0f22efb0724de56f8374ade6cdc93",
     "wof:hierarchy":[
         {
@@ -202,7 +206,7 @@
         }
     ],
     "wof:id":101874857,
-    "wof:lastmodified":1566612071,
+    "wof:lastmodified":1582316830,
     "wof:name":"Qala",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/874/859/101874859.geojson
+++ b/data/101/874/859/101874859.geojson
@@ -198,6 +198,10 @@
         "qs_pg:id":1283377
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"776a1df6e954d12f3281a6982d3d02b2",
     "wof:hierarchy":[
         {
@@ -208,7 +212,7 @@
         }
     ],
     "wof:id":101874859,
-    "wof:lastmodified":1566612071,
+    "wof:lastmodified":1582316830,
     "wof:name":"San Lawrenz",
     "wof:parent_id":85686995,
     "wof:placetype":"locality",

--- a/data/101/913/207/101913207.geojson
+++ b/data/101/913/207/101913207.geojson
@@ -192,6 +192,9 @@
         "wk:page":"Bir\u017cebbu\u0121a"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56982fb3b5a5e30d0ef54e0106b7f851",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":101913207,
-    "wof:lastmodified":1561845144,
+    "wof:lastmodified":1582316830,
     "wof:name":"Bir\u017cebbu\u0121a",
     "wof:parent_id":85686731,
     "wof:placetype":"locality",

--- a/data/101/913/211/101913211.geojson
+++ b/data/101/913/211/101913211.geojson
@@ -221,6 +221,9 @@
         "wk:page":"\u017bejtun"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"594cde236011503efd8b01f1bea9b32c",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":101913211,
-    "wof:lastmodified":1566612072,
+    "wof:lastmodified":1582316830,
     "wof:name":"\u017bejtun",
     "wof:parent_id":85686731,
     "wof:placetype":"locality",

--- a/data/117/561/295/3/1175612953.geojson
+++ b/data/117/561/295/3/1175612953.geojson
@@ -175,7 +175,6 @@
     "qs:type":"buffered point",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes_pg",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -196,6 +195,9 @@
         "wk:page":"G\u0127asri"
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d29be71422b5bf00216c3271703856e",
     "wof:hierarchy":[
         {
@@ -206,7 +208,7 @@
         }
     ],
     "wof:id":1175612953,
-    "wof:lastmodified":1566612061,
+    "wof:lastmodified":1582316829,
     "wof:name":"Ghasri",
     "wof:parent_id":85687013,
     "wof:placetype":"locality",

--- a/data/856/333/31/85633331.geojson
+++ b/data/856/333/31/85633331.geojson
@@ -1040,6 +1040,10 @@
     },
     "wof:country":"MT",
     "wof:country_alpha3":"MLT",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"6f0c796cc68173072005ca366672273b",
     "wof:hierarchy":[
         {
@@ -1056,7 +1060,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1566612055,
+    "wof:lastmodified":1582316828,
     "wof:name":"Malta",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/858/977/67/85897767.geojson
+++ b/data/858/977/67/85897767.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1082821
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63a7de46158916fa2f06f43db0a80f37",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566612056,
+    "wof:lastmodified":1582316829,
     "wof:name":"Ix-Xag\u0127ra ta' Barra",
     "wof:parent_id":101752447,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/71/85897771.geojson
+++ b/data/858/977/71/85897771.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1165583
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2257a81e76d40328b55536391a18414",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566612056,
+    "wof:lastmodified":1582316829,
     "wof:name":"Ta' l-Img\u0127ajjen",
     "wof:parent_id":101752455,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/75/85897775.geojson
+++ b/data/858/977/75/85897775.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":901628
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5589299513f09c87594d58f322513a77",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566612056,
+    "wof:lastmodified":1582316829,
     "wof:name":"Tal-Barmil",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/77/85897777.geojson
+++ b/data/858/977/77/85897777.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":901629
     },
     "wof:country":"MT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf59f41cbab80fe8a9fb03d3908b6dc4",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566612056,
+    "wof:lastmodified":1582316829,
     "wof:name":"Tal-\u0126amrija",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.