### PR TITLE
Name updates

### DIFF
--- a/data/856/333/31/85633331.geojson
+++ b/data/856/333/31/85633331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031511,
-    "geom:area_square_m":315535605.682612,
+    "geom:area_square_m":315535528.294841,
     "geom:bbox":"14.183606,35.806459,14.576155,36.082438",
     "geom:latitude":35.922644,
     "geom:longitude":14.399911,
@@ -54,6 +54,9 @@
     "name:arg_x_preferred":[
         "Malta"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0627\u0644\u0637\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u0627\u0644\u0637\u0627"
     ],
@@ -74,6 +77,9 @@
     ],
     "name:bam_x_preferred":[
         "Malti"
+    ],
+    "name:ban_x_preferred":[
+        "Malta"
     ],
     "name:bar_x_preferred":[
         "Malta"
@@ -171,6 +177,12 @@
     "name:dan_x_preferred":[
         "Malta"
     ],
+    "name:deu_at_x_preferred":[
+        "Malta"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Malta"
+    ],
     "name:deu_x_preferred":[
         "Malta"
     ],
@@ -190,6 +202,12 @@
         "\u039c\u03ac\u03bb\u03c4\u03b1"
     ],
     "name:eml_x_preferred":[
+        "Malta"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Malta"
+    ],
+    "name:eng_gb_x_preferred":[
         "Malta"
     ],
     "name:eng_x_preferred":[
@@ -259,6 +277,9 @@
     "name:gag_x_preferred":[
         "Malta"
     ],
+    "name:gcr_x_preferred":[
+        "Malt"
+    ],
     "name:ger_x_variant":[
         "Republik Malta"
     ],
@@ -276,6 +297,9 @@
     ],
     "name:gom_x_preferred":[
         "\u092e\u093e\u0932\u094d\u091f\u093e"
+    ],
+    "name:got_x_preferred":[
+        "\ud800\udf3c\ud800\udf30\ud800\udf3b\ud800\udf44\ud800\udf30"
     ],
     "name:grn_x_preferred":[
         "Malta"
@@ -320,6 +344,9 @@
         "M\u00e1lta"
     ],
     "name:hye_x_preferred":[
+        "\u0544\u0561\u056c\u0569\u0561"
+    ],
+    "name:hyw_x_preferred":[
         "\u0544\u0561\u056c\u0569\u0561"
     ],
     "name:ibo_x_preferred":[
@@ -645,6 +672,9 @@
     "name:pol_x_preferred":[
         "Malta"
     ],
+    "name:por_br_x_preferred":[
+        "Malta"
+    ],
     "name:por_x_preferred":[
         "Malta"
     ],
@@ -723,6 +753,9 @@
     "name:sna_x_preferred":[
         "Malta"
     ],
+    "name:snd_x_preferred":[
+        "\u0645\u0627\u0644\u067d\u0627"
+    ],
     "name:som_x_preferred":[
         "Malta"
     ],
@@ -766,6 +799,9 @@
         "Malta"
     ],
     "name:szl_x_preferred":[
+        "Malta"
+    ],
+    "name:szy_x_preferred":[
         "Malta"
     ],
     "name:tam_x_preferred":[
@@ -893,8 +929,26 @@
     "name:zha_x_preferred":[
         "Malta"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u9a6c\u8033\u4ed6"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u99ac\u723e\u4ed6"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Malta"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u99ac\u8033\u4ed6"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u9a6c\u8033\u4ed6"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u9a6c\u8033\u4ed6"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u99ac\u8033\u4ed6"
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u8033\u4ed6"
@@ -1061,7 +1115,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1583797390,
+    "wof:lastmodified":1587428772,
     "wof:name":"Malta",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.