### PR TITLE
mt concordances, placetype local, and more

### DIFF
--- a/data/117/561/294/1/1175612941.geojson
+++ b/data/117/561/294/1/1175612941.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.880116,
     "mps:longitude":14.5226,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -72,8 +72,14 @@
         "fips:code":"",
         "gn:id":8299705,
         "gp:id":24551391,
-        "hasc:id":"MT"
+        "hasc:id":"MT",
+        "iso:code":"MT-06",
+        "qs:local_id":"1105"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"beb5fd91f2182a14e75d6d5f8b64599d",
     "wof:hierarchy":[
@@ -92,7 +98,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"Bormla (Citta' Cospicua)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/117/561/295/5/1175612955.geojson
+++ b/data/117/561/295/5/1175612955.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11823,
     "eurostat:population_year":2020,
     "geom:area":0.00228,
-    "geom:area_square_m":22815191.504484,
+    "geom:area_square_m":22815003.768682,
     "geom:bbox":"14.319678,35.93063,14.407435,35.998387",
     "geom:latitude":35.962283,
     "geom:longitude":14.355762,
@@ -34,7 +34,7 @@
     "mps:latitude":35.952953,
     "mps:longitude":14.354882,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -288,10 +288,16 @@
         "gn:id":8299733,
         "gp:id":24551366,
         "hasc:id":"MT",
+        "iso:code":"MT-30",
+        "qs:local_id":"1537",
         "wd:id":"Q755979"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"0545e531618a6aff61dcfa2e935323ce",
+    "wof:geomhash":"3ed3941a11ee00f6e4bc8dd16b7cf95a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846226,
+    "wof:lastmodified":1695884323,
     "wof:name":"Mellieha",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/333/31/85633331.geojson
+++ b/data/856/333/31/85633331.geojson
@@ -1224,6 +1224,7 @@
         "hasc:id":"MT",
         "icao:code":"9G",
         "ioc:id":"MLT",
+        "iso:code":"MT",
         "itu:id":"MLT",
         "m49:code":"470",
         "marc:id":"mm",
@@ -1237,6 +1238,7 @@
         "wk:page":"Malta",
         "wmo:id":"ML"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MT",
     "wof:country_alpha3":"MLT",
     "wof:geom_alt":[
@@ -1259,7 +1261,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1694492263,
+    "wof:lastmodified":1695881376,
     "wof:name":"Malta",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/867/17/85686717.geojson
+++ b/data/856/867/17/85686717.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11140,
     "eurostat:population_year":2020,
     "geom:area":0.000836,
-    "geom:area_square_m":8379107.458602,
+    "geom:area_square_m":8379146.117138,
     "geom:bbox":"14.456766,35.811836,14.516673,35.841079",
     "geom:latitude":35.824862,
     "geom:longitude":14.483752,
@@ -34,7 +34,7 @@
     "mps:latitude":35.825039,
     "mps:longitude":14.473768,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -291,11 +291,17 @@
         "gn:id":8299766,
         "gp:id":24551383,
         "hasc:id":"MT",
+        "iso:code":"MT-68",
+        "qs:local_id":"1367",
         "unlc:id":"MT-68",
         "wd:id":"Q44417"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"6a98e5f275e5dc47d42de1880bcccec6",
+    "wof:geomhash":"d5ed3088859055b9874ac66c56d9b0ea",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846221,
+    "wof:lastmodified":1695884322,
     "wof:name":"Zurrieq",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/21/85686721.geojson
+++ b/data/856/867/21/85686721.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.830494,
     "mps:longitude":14.452041,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299743,
         "gp:id":24551377,
         "hasc:id":"MT",
+        "iso:code":"MT-44",
+        "qs:local_id":"1349",
         "unlc:id":"MT-44",
         "wd:id":"Q282203"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"932f386d8f626656fc5de70ea5ab1812",
+    "wof:geomhash":"73eae5b0dbad35be1728ff272b4d28c4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846221,
+    "wof:lastmodified":1695884322,
     "wof:name":"Qrendi",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/27/85686727.geojson
+++ b/data/856/867/27/85686727.geojson
@@ -177,8 +177,14 @@
         "gn:id":8299746,
         "gp:id":24551385,
         "hasc:id":"MT",
+        "iso:code":"MT-47",
+        "qs:local_id":"1351",
         "unlc:id":"MT-47"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"72ff75c5db33fc29a02b673a1dc58fea",
     "wof:hierarchy":[
@@ -197,7 +203,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695885334,
     "wof:name":"Safi",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/31/85686731.geojson
+++ b/data/856/867/31/85686731.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":13453,
     "eurostat:population_year":2020,
     "geom:area":0.00092,
-    "geom:area_square_m":9219604.26867,
+    "geom:area_square_m":9219614.048443,
     "geom:bbox":"14.500154,35.806459,14.549264,35.843872",
     "geom:latitude":35.821405,
     "geom:longitude":14.523412,
@@ -34,7 +34,7 @@
     "mps:latitude":35.816421,
     "mps:longitude":14.523029,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -284,10 +284,16 @@
         "gn:id":8299704,
         "gp:id":24551382,
         "hasc:id":"MT",
+        "iso:code":"MT-05",
+        "qs:local_id":"1315",
         "wd:id":"Q258028"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"dbea18d0ab9d6ead1beb0f631cd0046f",
+    "wof:geomhash":"a673597f83a7892d77f40fed02818a26",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -304,7 +310,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846222,
+    "wof:lastmodified":1695884322,
     "wof:name":"Birzebbugia",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/35/85686735.geojson
+++ b/data/856/867/35/85686735.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.844162,
     "mps:longitude":14.484289,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299727,
         "gp:id":24551378,
         "hasc:id":"MT",
+        "iso:code":"MT-23",
+        "qs:local_id":"1331",
         "unlc:id":"MT-23",
         "wd:id":"Q597464"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"6cc0ce985484ae93b5f202de5ec5a286",
+    "wof:geomhash":"d0ff8c7a8dd2b785bde4483c7f04ecc3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846221,
+    "wof:lastmodified":1695884322,
     "wof:name":"Kirkop",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/39/85686739.geojson
+++ b/data/856/867/39/85686739.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.845117,
     "mps:longitude":14.467489,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -262,9 +262,15 @@
         "gn:id":8299721,
         "gp:id":24551381,
         "hasc:id":"MT",
+        "iso:code":"MT-33",
+        "qs:local_id":"1340",
         "unlc:id":"MT-33",
         "wd:id":"Q1017953"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"f0e03c8be679d99d0bf36bc26f2a414a",
     "wof:hierarchy":[
@@ -283,7 +289,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Mqabba",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/43/85686743.geojson
+++ b/data/856/867/43/85686743.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3766,
     "eurostat:population_year":2020,
     "geom:area":0.000467,
-    "geom:area_square_m":4680513.580998,
+    "geom:area_square_m":4680413.464142,
     "geom:bbox":"14.526729,35.819142,14.572577,35.84951",
     "geom:latitude":35.839077,
     "geom:longitude":14.55038,
@@ -34,7 +34,7 @@
     "mps:latitude":35.84132,
     "mps:longitude":14.553852,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299732,
         "gp:id":24551380,
         "hasc:id":"MT",
+        "iso:code":"MT-28",
+        "qs:local_id":"1336",
         "unlc:id":"MT-28",
         "wd:id":"Q781921"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"5096ab2ae00f4f315feba8c218d8fa46",
+    "wof:geomhash":"c06952171002ab30cbc91be42bda1f84",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846222,
+    "wof:lastmodified":1695884322,
     "wof:name":"Marsaxlokk",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/47/85686747.geojson
+++ b/data/856/867/47/85686747.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.852697,
     "mps:longitude":14.503663,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -267,11 +267,17 @@
         "gn:id":8299715,
         "gp:id":24551389,
         "hasc:id":"MT",
+        "iso:code":"MT-11",
+        "qs:local_id":"1320",
         "unlc:id":"MT-11",
         "wd:id":"Q1018153"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"9138bf95b6eec009be2f844d285b2f4e",
+    "wof:geomhash":"a433ef006334eaa210070a579d64ac53",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -288,7 +294,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846224,
+    "wof:lastmodified":1695884322,
     "wof:name":"Gudja",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/49/85686749.geojson
+++ b/data/856/867/49/85686749.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":4928,
     "eurostat:population_year":2020,
     "geom:area":0.000383,
-    "geom:area_square_m":3836776.329301,
+    "geom:area_square_m":3836768.71413,
     "geom:bbox":"14.504496,35.831451,14.527912,35.861835",
     "geom:latitude":35.845237,
     "geom:longitude":14.516364,
@@ -34,7 +34,7 @@
     "mps:latitude":35.845009,
     "mps:longitude":14.517339,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299714,
         "gp:id":24551379,
         "hasc:id":"MT",
+        "iso:code":"MT-17",
+        "qs:local_id":"1326",
         "unlc:id":"MT-17",
         "wd:id":"Q426385"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"170ba5bbd138f0e8d50385c45a305306",
+    "wof:geomhash":"aa7e536091a35e00aabcb959e48869c5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846224,
+    "wof:lastmodified":1695884322,
     "wof:name":"Ghaxaq",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/53/85686753.geojson
+++ b/data/856/867/53/85686753.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2958,
     "eurostat:population_year":2020,
     "geom:area":0.000072,
-    "geom:area_square_m":725535.302221,
+    "geom:area_square_m":725530.447207,
     "geom:bbox":"14.498717,35.857204,14.51454,35.865284",
     "geom:latitude":35.861307,
     "geom:longitude":14.506753,
@@ -34,7 +34,7 @@
     "mps:latitude":35.861982,
     "mps:longitude":14.506213,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -198,10 +198,16 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01157",
         "eurostat:nuts_2021_id":"MT01157",
+        "iso:code":"MT-53",
+        "qs:local_id":"1157",
         "wd:id":"Q1087776"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"6cea3b8b5391f9a0c12926bce22d6a41",
+    "wof:geomhash":"78f2ef3959369d4905babb784afeef5f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -218,7 +224,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846223,
+    "wof:lastmodified":1695884322,
     "wof:name":"Santa Lucija",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/57/85686757.geojson
+++ b/data/856/867/57/85686757.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.847184,
     "mps:longitude":14.425246,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8299754,
         "gp:id":56043491,
         "hasc:id":"MT",
+        "iso:code":"MT-55",
+        "qs:local_id":"1409",
         "unlc:id":"MT-55"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"08907f89107472ec3fef9a682d637bc4",
     "wof:hierarchy":[
@@ -154,7 +160,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Siggiewi (Citta' Ferdinand)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/63/85686763.geojson
+++ b/data/856/867/63/85686763.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3730,
     "eurostat:population_year":2020,
     "geom:area":0.000569,
-    "geom:area_square_m":5704497.655023,
+    "geom:area_square_m":5704505.799259,
     "geom:bbox":"14.35996,35.846204,14.397807,35.872696",
     "geom:latitude":35.860452,
     "geom:longitude":14.381528,
@@ -34,7 +34,7 @@
     "mps:latitude":35.85957,
     "mps:longitude":14.383104,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299706,
         "gp:id":24551369,
         "hasc:id":"MT",
+        "iso:code":"MT-07",
+        "qs:local_id":"1416",
         "unlc:id":"MT-07",
         "wd:id":"Q905641"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"de5c5331e93baac53b771024277cbf9a",
+    "wof:geomhash":"afb1bfe59a3abad6cb657cf88b2a4e1f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846223,
+    "wof:lastmodified":1695884322,
     "wof:name":"Dingli",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/67/85686767.geojson
+++ b/data/856/867/67/85686767.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.857471,
     "mps:longitude":14.532266,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8299765,
         "gp:id":24551384,
         "hasc:id":"MT",
+        "iso:code":"MT-67",
+        "qs:local_id":"1310",
         "unlc:id":"MT-67"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"a519355f471c2d5904a9fc2f84eb6014",
     "wof:hierarchy":[
@@ -154,7 +160,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Zejtun (Citta' Beland)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/71/85686771.geojson
+++ b/data/856/867/71/85686771.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.866271,
     "mps:longitude":14.513351,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -288,14 +288,20 @@
         "gn:id":8299757,
         "gp:id":24551402,
         "hasc:id":"MT",
+        "iso:code":"MT-59",
+        "qs:local_id":"1162",
         "unlc:id":"MT-59",
         "wd:id":"Q744001"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752375
     ],
     "wof:country":"MT",
-    "wof:geomhash":"5d75983a1146ece254a744fe43d6f09d",
+    "wof:geomhash":"3ac297f34f34217aefc5d830412e4bd6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846224,
+    "wof:lastmodified":1695884322,
     "wof:name":"Tarxien",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/75/85686775.geojson
+++ b/data/856/867/75/85686775.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":6379,
     "eurostat:population_year":2020,
     "geom:area":0.000676,
-    "geom:area_square_m":6778421.09339,
+    "geom:area_square_m":6778454.152292,
     "geom:bbox":"14.4576,35.82798,14.513854,35.875633",
     "geom:latitude":35.855689,
     "geom:longitude":14.485374,
@@ -34,7 +34,7 @@
     "mps:latitude":35.860157,
     "mps:longitude":14.482604,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -279,11 +279,17 @@
         "gn:id":8299729,
         "gp:id":24551411,
         "hasc:id":"MT",
+        "iso:code":"MT-25",
+        "qs:local_id":"1133",
         "unlc:id":"MT-25",
         "wd:id":"Q475585"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"b3dfa7e1042878ca85ab339c53efeed3",
+    "wof:geomhash":"c15cc9122220db331b310e9dfb4c3918",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +306,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846222,
+    "wof:lastmodified":1695884322,
     "wof:name":"Luqa",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/81/85686781.geojson
+++ b/data/856/867/81/85686781.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.871796,
     "mps:longitude":14.521966,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:afr_x_preferred":[
@@ -351,11 +351,17 @@
         "gn:id":8299707,
         "gp:id":24551403,
         "hasc:id":"MT",
+        "iso:code":"MT-08",
+        "qs:local_id":"1117",
         "unlc:id":"MT-08",
         "wd:id":"Q44388"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"ac96ccc8391462215eb131825c9d56b2",
+    "wof:geomhash":"9aa35202ef2ebe019881901649374d21",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -372,7 +378,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846222,
+    "wof:lastmodified":1695884322,
     "wof:name":"Fgura",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/85/85686785.geojson
+++ b/data/856/867/85/85686785.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.85821,
     "mps:longitude":14.557758,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -288,11 +288,17 @@
         "gn:id":8299731,
         "gp:id":24551386,
         "hasc:id":"MT",
+        "iso:code":"MT-27",
+        "qs:local_id":"1335",
         "unlc:id":"MT-27",
         "wd:id":"Q534571"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"1a71986a6fbba65ed9dacf2303d090f5",
+    "wof:geomhash":"2619aa3b2f6ce3dd74c80d6a905db952",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846223,
+    "wof:lastmodified":1695884322,
     "wof:name":"Marsaskala",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/89/85686789.geojson
+++ b/data/856/867/89/85686789.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.872651,
     "mps:longitude":14.436015,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -132,8 +132,14 @@
         "fips:code":"",
         "gn:id":8299763,
         "gp:id":24551370,
-        "hasc:id":"MT"
+        "hasc:id":"MT",
+        "iso:code":"MT-66",
+        "qs:local_id":"1407"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"4ab651c495bd770c5ae7495504ba7345",
     "wof:hierarchy":[
@@ -152,7 +158,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Zebbug (Malta) (Citta' Rohan)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/867/99/85686799.geojson
+++ b/data/856/867/99/85686799.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.887013,
     "mps:longitude":14.406122,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -66,8 +66,14 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01402",
         "eurostat:nuts_2021_id":"MT01402",
+        "iso:code":"MT-29",
+        "qs:local_id":"1402",
         "unlc:id":"MT-29"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"d1d99d9fc98e40607230f47b345f55c4",
     "wof:hierarchy":[
@@ -86,7 +92,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Mdina (Citta' Notabile)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/03/85686803.geojson
+++ b/data/856/868/03/85686803.geojson
@@ -180,8 +180,14 @@
         "gn:id":8299730,
         "gp:id":24551393,
         "hasc:id":"MT",
+        "iso:code":"MT-26",
+        "qs:local_id":"1134",
         "unlc:id":"MT-26"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"c451e21a54f870a50d31ac5f1b8a3bbc",
     "wof:hierarchy":[
@@ -200,7 +206,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695885334,
     "wof:name":"Marsa",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/05/85686805.geojson
+++ b/data/856/868/05/85686805.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.878329,
     "mps:longitude":14.469378,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8299742,
         "gp:id":24551406,
         "hasc:id":"MT",
+        "iso:code":"MT-43",
+        "qs:local_id":"1206",
         "unlc:id":"MT-43"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"67f92acb709f4be6f3689db6c24bd0de",
     "wof:hierarchy":[
@@ -154,7 +160,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Qormi (Citta' Pinto)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/09/85686809.geojson
+++ b/data/856/868/09/85686809.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.875427,
     "mps:longitude":14.539161,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8299762,
         "gp:id":24551397,
         "hasc:id":"MT",
+        "iso:code":"MT-64",
+        "qs:local_id":"1108",
         "unlc:id":"MT-64"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"b485fc681d12ce759a31cecebe044770",
     "wof:hierarchy":[
@@ -154,7 +160,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Zabbar (Citta' Hompesch)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/15/85686815.geojson
+++ b/data/856/868/15/85686815.geojson
@@ -183,8 +183,14 @@
         "gn:id":8299738,
         "gp:id":24551398,
         "hasc:id":"MT",
+        "iso:code":"MT-39",
+        "qs:local_id":"1145",
         "unlc:id":"MT-39"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"0b85db27feb3c20361f714f2f2a09e9a",
     "wof:hierarchy":[
@@ -203,7 +209,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695885335,
     "wof:name":"Paola",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/19/85686819.geojson
+++ b/data/856/868/19/85686819.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.892505,
     "mps:longitude":14.399531,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -208,11 +208,17 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01468",
         "eurostat:nuts_2021_id":"MT01468",
+        "iso:code":"MT-35",
+        "qs:local_id":"1468",
         "unlc:id":"MT-35",
         "wd:id":"Q656837"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"06079fc19f0a2331cb4cc50bab4e0f58",
+    "wof:geomhash":"501de387378043faa6d334584d22ff0f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -229,7 +235,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846215,
+    "wof:lastmodified":1695884322,
     "wof:name":"Mtarfa",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/23/85686823.geojson
+++ b/data/856/868/23/85686823.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.887244,
     "mps:longitude":14.487524,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -232,14 +232,20 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01227",
         "eurostat:nuts_2021_id":"MT01227",
+        "iso:code":"MT-18",
+        "qs:local_id":"1227",
         "unlc:id":"MT-18",
         "wd:id":"Q343001"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752395
     ],
     "wof:country":"MT",
-    "wof:geomhash":"8386160326510c2ccfe3ba7315d3ff05",
+    "wof:geomhash":"faa47e36b63ac100ae99aaefab51534b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -256,7 +262,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846217,
+    "wof:lastmodified":1695884322,
     "wof:name":"Hamrun",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/25/85686825.geojson
+++ b/data/856/868/25/85686825.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.887871,
     "mps:longitude":14.516917,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -66,8 +66,14 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01104",
         "eurostat:nuts_2021_id":"MT01104",
+        "iso:code":"MT-20",
+        "qs:local_id":"1104",
         "unlc:id":"MT-20"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"b8efe527df5870f32cd95c82687b2245",
     "wof:hierarchy":[
@@ -86,7 +92,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Isla (Citta' Invicta)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/29/85686829.geojson
+++ b/data/856/868/29/85686829.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.884672,
     "mps:longitude":14.548704,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -261,9 +261,15 @@
         "gn:id":8299761,
         "gp:id":24551401,
         "hasc:id":"MT",
+        "iso:code":"MT-63",
+        "qs:local_id":"1165",
         "unlc:id":"MT-63",
         "wd:id":"Q520962"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"842bf103342ea70b309ab7a8b06fe0ad",
     "wof:hierarchy":[
@@ -282,7 +288,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Xghajra",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/37/85686837.geojson
+++ b/data/856/868/37/85686837.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.889823,
     "mps:longitude":14.47807,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299752,
         "gp:id":24551410,
         "hasc:id":"MT",
+        "iso:code":"MT-54",
+        "qs:local_id":"1258",
         "unlc:id":"MT-54",
         "wd:id":"Q585420"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"65f056cf5c3fd5e124920ae4ba7a8e10",
+    "wof:geomhash":"024f0a2cf05034528cec16c37201b05f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846216,
+    "wof:lastmodified":1695884322,
     "wof:name":"Santa Venera",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/41/85686841.geojson
+++ b/data/856/868/41/85686841.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.887249,
     "mps:longitude":14.522745,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8299702,
         "gp:id":24551404,
         "hasc:id":"MT",
+        "iso:code":"MT-03",
+        "qs:local_id":"1103",
         "unlc:id":"MT-03"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"0908151ee17f1fa5035ac8c514391f21",
     "wof:hierarchy":[
@@ -154,7 +160,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884322,
     "wof:name":"Birgu (Citta' Vittoriosa)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/45/85686845.geojson
+++ b/data/856/868/45/85686845.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":5255,
     "eurostat:population_year":2020,
     "geom:area":0.000047,
-    "geom:area_square_m":469533.21191,
+    "geom:area_square_m":469533.208542,
     "geom:bbox":"14.489891,35.888569,14.497448,35.896665",
     "geom:latitude":35.892458,
     "geom:longitude":14.493798,
@@ -34,7 +34,7 @@
     "mps:latitude":35.892449,
     "mps:longitude":14.493726,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -216,10 +216,16 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01247",
         "eurostat:nuts_2021_id":"MT01247",
+        "iso:code":"MT-41",
+        "qs:local_id":"1247",
         "wd:id":"Q223689"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"f8f7c390ada5324ed74464d2437caf1c",
+    "wof:geomhash":"4bac7f612863f6d5ee2f821506386fe6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -236,7 +242,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846215,
+    "wof:lastmodified":1695884322,
     "wof:name":"Pieta'",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/51/85686851.geojson
+++ b/data/856/868/51/85686851.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11630,
     "eurostat:population_year":2020,
     "geom:area":0.00066,
-    "geom:area_square_m":6607950.006705,
+    "geom:area_square_m":6608023.981356,
     "geom:bbox":"14.408804,35.881081,14.458171,35.901722",
     "geom:latitude":35.891372,
     "geom:longitude":14.430443,
@@ -34,7 +34,7 @@
     "mps:latitude":35.891739,
     "mps:longitude":14.425036,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -295,11 +295,17 @@
         "gn:id":8299700,
         "gp:id":24551373,
         "hasc:id":"MT",
+        "iso:code":"MT-01",
+        "qs:local_id":"1412",
         "unlc:id":"MT-01",
         "wd:id":"Q44557"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"6bdc8b4c7182b6fc331f68b390440ba9",
+    "wof:geomhash":"45995f60e0b9fe7c985d570a402b9bb9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -316,7 +322,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846215,
+    "wof:lastmodified":1695884322,
     "wof:name":"Attard",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/55/85686855.geojson
+++ b/data/856/868/55/85686855.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2053,
     "eurostat:population_year":2020,
     "geom:area":0.000096,
-    "geom:area_square_m":959011.271109,
+    "geom:area_square_m":958998.083937,
     "geom:bbox":"14.497426,35.885983,14.510959,35.899178",
     "geom:latitude":35.892004,
     "geom:longitude":14.50363,
@@ -34,7 +34,7 @@
     "mps:latitude":35.892088,
     "mps:longitude":14.503732,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -280,11 +280,17 @@
         "gn:id":8299708,
         "gp:id":56043492,
         "hasc:id":"MT",
+        "iso:code":"MT-09",
+        "qs:local_id":"1118",
         "unlc:id":"MT-09",
         "wd:id":"Q832807"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"7188f0381a9c4332aba3b70eeec01946",
+    "wof:geomhash":"37dafc8f88f6dbf83435efbedee5e56b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -301,7 +307,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846216,
+    "wof:lastmodified":1695884322,
     "wof:name":"Floriana",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/59/85686859.geojson
+++ b/data/856/868/59/85686859.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.897046,
     "mps:longitude":14.452836,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,14 +273,20 @@
         "gn:id":8299701,
         "gp:id":24551375,
         "hasc:id":"MT",
+        "iso:code":"MT-02",
+        "qs:local_id":"1413",
         "unlc:id":"MT-02",
         "wd:id":"Q789794"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752405
     ],
     "wof:country":"MT",
-    "wof:geomhash":"13905cbc1b6545d960990e0144e0ff0a",
+    "wof:geomhash":"3259ef3bcec5019fb928eaab9231b1a2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -297,7 +303,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846214,
+    "wof:lastmodified":1695884322,
     "wof:name":"Balzan",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/63/85686863.geojson
+++ b/data/856/868/63/85686863.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.890921,
     "mps:longitude":14.531934,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:afr_x_preferred":[
@@ -402,11 +402,17 @@
         "gn:id":8299725,
         "gp:id":24551392,
         "hasc:id":"MT",
+        "iso:code":"MT-21",
+        "qs:local_id":"1129",
         "unlc:id":"MT-21",
         "wd:id":"Q533257"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"c6974a4afd6c4286457fcd12d28749ab",
+    "wof:geomhash":"873a29ec3c7854f9aa9650ee2c560e7c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -423,7 +429,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846217,
+    "wof:lastmodified":1695884322,
     "wof:name":"Kalkara",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/69/85686869.geojson
+++ b/data/856/868/69/85686869.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.899534,
     "mps:longitude":14.495958,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -199,11 +199,17 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01261",
         "eurostat:nuts_2021_id":"MT01261",
+        "iso:code":"MT-58",
+        "qs:local_id":"1261",
         "unlc:id":"MT-58",
         "wd:id":"Q1017348"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"13f47a2734b39c9c421d3678cfb5415b",
+    "wof:geomhash":"b0f09ca213af834d1d6a1677b74d61c0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -220,7 +226,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846214,
+    "wof:lastmodified":1695884322,
     "wof:name":"Ta' Xbiex",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/71/85686871.geojson
+++ b/data/856/868/71/85686871.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.901165,
     "mps:longitude":14.442385,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -264,14 +264,20 @@
         "gn:id":8299728,
         "gp:id":24551371,
         "hasc:id":"MT",
+        "iso:code":"MT-24",
+        "qs:local_id":"1432",
         "unlc:id":"MT-24",
         "wd:id":"Q782049"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752415
     ],
     "wof:country":"MT",
-    "wof:geomhash":"7e3a1896fc9865a4ddd6ee041a7fd09a",
+    "wof:geomhash":"bfdf7ef9d40d35f32878b3b74af68589",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -288,7 +294,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846218,
+    "wof:lastmodified":1695884323,
     "wof:name":"Lija",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/75/85686875.geojson
+++ b/data/856/868/75/85686875.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11553,
     "eurostat:population_year":2020,
     "geom:area":0.002659,
-    "geom:area_square_m":26639003.600121,
+    "geom:area_square_m":26638861.626183,
     "geom:bbox":"14.328263,35.861557,14.416919,35.90765",
     "geom:latitude":35.886047,
     "geom:longitude":14.37413,
@@ -34,7 +34,7 @@
     "mps:latitude":35.886027,
     "mps:longitude":14.374147,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -299,10 +299,16 @@
         "gn:id":-99,
         "gp:id":56043491,
         "hasc:id":"MT",
+        "iso:code":"MT-46",
+        "qs:local_id":"1450",
         "wd:id":"Q44381"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"3b7ffff3563f9f5301ad038e0f549eec",
+    "wof:geomhash":"dbca6a47dacdf1abf6a8067ac81076a3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -319,7 +325,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846216,
+    "wof:lastmodified":1695884323,
     "wof:name":"Rabat (Malta)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/79/85686879.geojson
+++ b/data/856/868/79/85686879.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.896094,
     "mps:longitude":14.465404,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:afr_x_preferred":[
@@ -351,14 +351,20 @@
         "gn:id":8299703,
         "gp:id":24551412,
         "hasc:id":"MT",
+        "iso:code":"MT-04",
+        "qs:local_id":"1214",
         "unlc:id":"MT-04",
         "wd:id":"Q39583"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752419
     ],
     "wof:country":"MT",
-    "wof:geomhash":"9639d74b5adc8f64d657729351bde390",
+    "wof:geomhash":"cb19732df1f942d90ce38a4e3f75570d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -375,7 +381,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846217,
+    "wof:lastmodified":1695884323,
     "wof:name":"Birkirkara",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/83/85686883.geojson
+++ b/data/856/868/83/85686883.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.898879,
     "mps:longitude":14.483409,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -324,14 +324,20 @@
         "gn:id":8299722,
         "gp:id":24551414,
         "hasc:id":"MT",
+        "iso:code":"MT-34",
+        "qs:local_id":"1241",
         "unlc:id":"MT-34",
         "wd:id":"Q585187"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752421
     ],
     "wof:country":"MT",
-    "wof:geomhash":"c43743434e011a77285added9c900030",
+    "wof:geomhash":"5e6afa13581b7bbe06bbaff81abcb5dd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -348,7 +354,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846217,
+    "wof:lastmodified":1695884323,
     "wof:name":"Msida",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/89/85686889.geojson
+++ b/data/856/868/89/85686889.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.898936,
     "mps:longitude":14.512859,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8334638,
         "gp:id":24551399,
         "hasc:id":"MT",
+        "iso:code":"MT-60",
+        "qs:local_id":"1101",
         "unlc:id":"MT-60"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752423
     ],
@@ -157,7 +163,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884323,
     "wof:name":"Valletta (Citta' Umilissima)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/93/85686893.geojson
+++ b/data/856/868/93/85686893.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.905151,
     "mps:longitude":14.492526,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:cat_x_preferred":[
@@ -93,8 +93,14 @@
     "wof:concordances":{
         "eg:gisco_id":"MT_MT01221",
         "eurostat:nuts_2021_id":"MT01221",
+        "iso:code":"MT-12",
+        "qs:local_id":"1221",
         "unlc:id":"MT-12"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"b0d16ca87a95df9878c809cc4a1b2bd1",
     "wof:hierarchy":[
@@ -113,7 +119,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884323,
     "wof:name":"Gzira",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/868/97/85686897.geojson
+++ b/data/856/868/97/85686897.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.90992,
     "mps:longitude":14.456322,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -261,14 +261,20 @@
         "gn:id":8299718,
         "gp:id":24551409,
         "hasc:id":"MT",
+        "iso:code":"MT-19",
+        "qs:local_id":"1428",
         "unlc:id":"MT-19",
         "wd:id":"Q304589"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752427
     ],
     "wof:country":"MT",
-    "wof:geomhash":"cc6a6fa46017458ed288b877232c7a39",
+    "wof:geomhash":"b230f2c0d38f93ed9d8641d997f23a9b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -285,7 +291,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846216,
+    "wof:lastmodified":1695884323,
     "wof:name":"Iklin",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/01/85686901.geojson
+++ b/data/856/869/01/85686901.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":15107,
     "eurostat:population_year":2020,
     "geom:area":0.000263,
-    "geom:area_square_m":2630875.270122,
+    "geom:area_square_m":2630946.504724,
     "geom:bbox":"14.462099,35.902618,14.490283,35.917023",
     "geom:latitude":35.909032,
     "geom:longitude":14.475147,
@@ -34,7 +34,7 @@
     "mps:latitude":35.908526,
     "mps:longitude":14.475416,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -279,10 +279,16 @@
         "gn:id":8299747,
         "gp:id":24551407,
         "hasc:id":"MT",
+        "iso:code":"MT-49",
+        "qs:local_id":"1253",
         "wd:id":"Q39507"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"136efffcd190c303a81885e0dc08828f",
+    "wof:geomhash":"5b4426bfc3bd74f6abfd23dce088fa3d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -299,7 +305,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846220,
+    "wof:lastmodified":1695884323,
     "wof:name":"San Gwann",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/07/85686907.geojson
+++ b/data/856/869/07/85686907.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":24358,
     "eurostat:population_year":2020,
     "geom:area":0.00013,
-    "geom:area_square_m":1298220.268142,
+    "geom:area_square_m":1298158.577232,
     "geom:bbox":"14.492942,35.905403,14.515051,35.919005",
     "geom:latitude":35.91166,
     "geom:longitude":14.502794,
@@ -34,7 +34,7 @@
     "mps:latitude":35.912581,
     "mps:longitude":14.501705,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -345,11 +345,17 @@
         "gn:id":8299755,
         "gp:id":24551395,
         "hasc:id":"MT",
+        "iso:code":"MT-56",
+        "qs:local_id":"1259",
         "unlc:id":"MT-56",
         "wd:id":"Q39526"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"3cb279ed3b107b4e27db6d8697836535",
+    "wof:geomhash":"c5df30ddaaeae198b304e6a8b12d0888",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -366,7 +372,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846219,
+    "wof:lastmodified":1695884323,
     "wof:name":"Sliema",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/11/85686911.geojson
+++ b/data/856/869/11/85686911.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":21426,
     "eurostat:population_year":2020,
     "geom:area":0.00068,
-    "geom:area_square_m":6807520.834125,
+    "geom:area_square_m":6807561.340481,
     "geom:bbox":"14.393221,35.89732,14.439142,35.928997",
     "geom:latitude":35.912959,
     "geom:longitude":14.419082,
@@ -34,7 +34,7 @@
     "mps:latitude":35.910976,
     "mps:longitude":14.420647,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -306,11 +306,17 @@
         "gn:id":8299734,
         "gp:id":24551367,
         "hasc:id":"MT",
+        "iso:code":"MT-32",
+        "qs:local_id":"1539",
         "unlc:id":"MT-32",
         "wd:id":"Q39520"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"d505520fdee0179dd637876eefad6368",
+    "wof:geomhash":"99f309726928ac56645bf47fdc2ded58",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -327,7 +333,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846218,
+    "wof:lastmodified":1695884323,
     "wof:name":"Mosta",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/15/85686915.geojson
+++ b/data/856/869/15/85686915.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.914259,
     "mps:longitude":14.489573,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -132,8 +132,14 @@
         "fips:code":"MT49",
         "gn:id":8299748,
         "gp:id":-56043491,
-        "hasc:id":"MT"
+        "hasc:id":"MT",
+        "iso:code":"MT-48",
+        "qs:local_id":"1252"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"63bf2626aed79aa47eab42a8c8646a6b",
     "wof:hierarchy":[
@@ -152,7 +158,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884323,
     "wof:name":"San Giljan",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/19/85686919.geojson
+++ b/data/856/869/19/85686919.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.922688,
     "mps:longitude":14.454445,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:cat_x_preferred":[
@@ -161,8 +161,14 @@
         "gn:id":8299712,
         "gp:id":24551405,
         "hasc:id":"MT",
+        "iso:code":"MT-15",
+        "qs:local_id":"1524",
         "unlc:id":"MT-15"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"c95a98e49e166af741b9cba30c7bdade",
     "wof:hierarchy":[
@@ -181,7 +187,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695884323,
     "wof:name":"Gharghur",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/25/85686925.geojson
+++ b/data/856/869/25/85686925.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.918853,
     "mps:longitude":14.471317,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -282,14 +282,20 @@
         "gn:id":8299756,
         "gp:id":24551413,
         "hasc:id":"MT",
+        "iso:code":"MT-57",
+        "qs:local_id":"1260",
         "unlc:id":"MT-57",
         "wd:id":"Q220667"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752437
     ],
     "wof:country":"MT",
-    "wof:geomhash":"4311b31ac5069a9e198326efcc17296c",
+    "wof:geomhash":"f4f18392cb4c1cfd6eb9b29483925be2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +312,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846221,
+    "wof:lastmodified":1695884323,
     "wof:name":"Swieqi",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/29/85686929.geojson
+++ b/data/856/869/29/85686929.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3928,
     "eurostat:population_year":2020,
     "geom:area":0.00162,
-    "geom:area_square_m":16219137.018378,
+    "geom:area_square_m":16219283.780128,
     "geom:bbox":"14.33229,35.896694,14.404726,35.940583",
     "geom:latitude":35.917522,
     "geom:longitude":14.364658,
@@ -34,7 +34,7 @@
     "mps:latitude":35.918405,
     "mps:longitude":14.365206,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -274,11 +274,17 @@
         "gn:id":8299720,
         "gp:id":24551364,
         "hasc:id":"MT",
+        "iso:code":"MT-31",
+        "qs:local_id":"1538",
         "unlc:id":"MT-31",
         "wd:id":"Q691220"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"e342dc26704fa08116bb0275ff634ca6",
+    "wof:geomhash":"1c9c7fa1e43cdbc4b237fc58f393cde2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -295,7 +301,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846218,
+    "wof:lastmodified":1695884323,
     "wof:name":"Mgarr",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/33/85686933.geojson
+++ b/data/856/869/33/85686933.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.931959,
     "mps:longitude":14.475458,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:cat_x_preferred":[
@@ -215,8 +215,14 @@
         "gn:id":8299739,
         "gp:id":24551408,
         "hasc:id":"MT",
+        "iso:code":"MT-40",
+        "qs:local_id":"1246",
         "unlc:id":"MT-40"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101752439
     ],
@@ -238,7 +244,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"Pembroke",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/37/85686937.geojson
+++ b/data/856/869/37/85686937.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.937062,
     "mps:longitude":14.436896,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -285,11 +285,17 @@
         "gn:id":8299737,
         "gp:id":56043491,
         "hasc:id":"MT",
+        "iso:code":"MT-38",
+        "qs:local_id":"1544",
         "unlc:id":"MT-38",
         "wd:id":"Q44397"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"ca017a4b0c896ff949cea7d58d20b5bf",
+    "wof:geomhash":"d26c75f5d7334389a7302622514b9a2b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +312,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846219,
+    "wof:lastmodified":1695884323,
     "wof:name":"Naxxar",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/43/85686943.geojson
+++ b/data/856/869/43/85686943.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":35.939221,
     "mps:longitude":14.400375,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -132,8 +132,14 @@
         "fips:code":"MT52",
         "gn:id":8299751,
         "gp:id":24551368,
-        "hasc:id":"MT"
+        "hasc:id":"MT",
+        "iso:code":"MT-51",
+        "qs:local_id":"1555"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"05bbe528e015b40cd2fc2054736d82df",
     "wof:hierarchy":[
@@ -152,7 +158,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"San Pawl Il-Bahar",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/53/85686953.geojson
+++ b/data/856/869/53/85686953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00001,
-    "geom:area_square_m":98355.401313,
+    "geom:area_square_m":98344.342077,
     "geom:bbox":"14.31711,36.011977,14.322982,36.015079",
     "geom:latitude":36.013583,
     "geom:longitude":14.319727,
@@ -22,7 +22,7 @@
     "mps:latitude":36.013649,
     "mps:longitude":14.319438,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -48,9 +48,16 @@
         85633331
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"MT-13",
+        "qs:local_id":"2622"
+    },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"6611df6b69ead00ccacda5c5bb5cd97f",
+    "wof:geomhash":"89d4f0b30fc4aab154e48bdac7efb850",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -67,7 +74,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1627522383,
+    "wof:lastmodified":1695884284,
     "wof:name":"Ghajnsielem u Kemmuna",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/59/85686959.geojson
+++ b/data/856/869/59/85686959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000274,
-    "geom:area_square_m":2742135.799997,
+    "geom:area_square_m":2742166.979375,
     "geom:bbox":"14.322284,36.004143,14.350336,36.020142",
     "geom:latitude":36.011722,
     "geom:longitude":14.336028,
@@ -22,7 +22,7 @@
     "mps:latitude":36.010983,
     "mps:longitude":14.335761,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -48,9 +48,16 @@
         85633331
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"MT-13",
+        "qs:local_id":"2622"
+    },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"c6fa3ad45cc734d0c5a6de9da86e1cd8",
+    "wof:geomhash":"df610a1da9ffb3f4fcd9cf8924c9cf5a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -67,7 +74,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1627522382,
+    "wof:lastmodified":1695884284,
     "wof:name":"Ghajnsielem u Kemmuna",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/61/85686961.geojson
+++ b/data/856/869/61/85686961.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.023742,
     "mps:longitude":14.250525,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -270,11 +270,17 @@
         "gn:id":8299753,
         "gp:id":24551350,
         "hasc:id":"-99",
+        "iso:code":"MT-52",
+        "qs:local_id":"2656",
         "unlc:id":"MT-52",
         "wd:id":"Q602037"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"c5347aebbd36bdcebfd6a79ac65ca8c6",
+    "wof:geomhash":"4a537ff6c3fe714b2ccfe9ba51a60f33",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -291,7 +297,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846218,
+    "wof:lastmodified":1695884323,
     "wof:name":"Sannat",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/65/85686965.geojson
+++ b/data/856/869/65/85686965.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.029323,
     "mps:longitude":14.225165,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -261,11 +261,17 @@
         "gn:id":8299735,
         "gp:id":24551354,
         "hasc:id":"-99",
+        "iso:code":"MT-36",
+        "qs:local_id":"2642",
         "unlc:id":"MT-36",
         "wd:id":"Q587462"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"a5b114baed21abf4a561cab3f8e331ef",
+    "wof:geomhash":"4f32a70bb4369e04896469cecb5caa41",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -282,7 +288,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846219,
+    "wof:lastmodified":1695884323,
     "wof:name":"Munxar",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/69/85686969.geojson
+++ b/data/856/869/69/85686969.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.02605,
     "mps:longitude":14.28347,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -147,8 +147,14 @@
         "fips:code":"",
         "gn:id":8299710,
         "gp:id":24551363,
-        "hasc:id":"-99"
+        "hasc:id":"-99",
+        "iso:code":"MT-13",
+        "qs:local_id":"2622"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"b941ea547bbfb086d42f286a4f88d558",
     "wof:hierarchy":[
@@ -167,7 +173,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"Ghajnsielem u Kemmuna",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/71/85686971.geojson
+++ b/data/856/869/71/85686971.geojson
@@ -213,8 +213,14 @@
         "gn:id":8299709,
         "gp:id":24551362,
         "hasc:id":"-99",
+        "iso:code":"MT-10",
+        "qs:local_id":"2619",
         "unlc:id":"MT-10"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"683d04553f63d04d1e26d2ff6e00fb11",
     "wof:hierarchy":[
@@ -233,7 +239,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695885335,
     "wof:name":"Fontana",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/77/85686977.geojson
+++ b/data/856/869/77/85686977.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.033288,
     "mps:longitude":14.261115,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -267,11 +267,17 @@
         "gn:id":8299760,
         "gp:id":24551360,
         "hasc:id":"-99",
+        "iso:code":"MT-62",
+        "qs:local_id":"2664",
         "unlc:id":"MT-62",
         "wd:id":"Q919921"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"5a8e168ed700e15d8b966b7d338995b4",
+    "wof:geomhash":"60bf650f72a302433f614cd8e6b0fb20",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -288,7 +294,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846220,
+    "wof:lastmodified":1695884323,
     "wof:name":"Xewkija",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/81/85686981.geojson
+++ b/data/856/869/81/85686981.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.044875,
     "mps:longitude":14.243008,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -138,8 +138,14 @@
         "fips:code":"",
         "gn:id":8299745,
         "gp:id":24551352,
-        "hasc:id":"-99"
+        "hasc:id":"-99",
+        "iso:code":"MT-45",
+        "qs:local_id":"2611"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"0286e0a3499b35745b07bdd402928f81",
     "wof:hierarchy":[
@@ -158,7 +164,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"Rabat (Ghawdex) (Citta' Vittoria)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/85/85686985.geojson
+++ b/data/856/869/85/85686985.geojson
@@ -147,8 +147,14 @@
         "gn:id":8299741,
         "gp:id":24551357,
         "hasc:id":"-99",
+        "iso:code":"MT-42",
+        "qs:local_id":"2648",
         "unlc:id":"MT-42"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"bb11a9327880073786bd509f31fe5cc3",
     "wof:hierarchy":[
@@ -167,7 +173,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695885335,
     "wof:name":"Qala",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/89/85686989.geojson
+++ b/data/856/869/89/85686989.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":1809,
     "eurostat:population_year":2020,
     "geom:area":0.000544,
-    "geom:area_square_m":5437180.556564,
+    "geom:area_square_m":5437225.09108,
     "geom:bbox":"14.193307,36.031316,14.233804,36.055474",
     "geom:latitude":36.04268,
     "geom:longitude":14.215418,
@@ -34,7 +34,7 @@
     "mps:latitude":36.04317,
     "mps:longitude":14.215704,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -261,11 +261,17 @@
         "gn:id":8299726,
         "gp:id":24551358,
         "hasc:id":"-99",
+        "iso:code":"MT-22",
+        "qs:local_id":"2630",
         "unlc:id":"MT-22",
         "wd:id":"Q674679"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"78513e11602e970d2196995cb0420a2f",
+    "wof:geomhash":"7b8151213798337f1d66cbca50b09afb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -282,7 +288,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846219,
+    "wof:lastmodified":1695884323,
     "wof:name":"Kercem",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/95/85686995.geojson
+++ b/data/856/869/95/85686995.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.052028,
     "mps:longitude":14.198206,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -195,8 +195,14 @@
         "fips:code":"MT50",
         "gn:id":8299749,
         "gp:id":24551361,
-        "hasc:id":"-99"
+        "hasc:id":"-99",
+        "iso:code":"MT-50",
+        "qs:local_id":"2654"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"2d2befdd3b0de393e1df8e76b8be9a2f",
     "wof:hierarchy":[
@@ -215,7 +221,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"San Lawrenz",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/869/99/85686999.geojson
+++ b/data/856/869/99/85686999.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.047957,
     "mps:longitude":14.294282,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -258,11 +258,17 @@
         "gn:id":8299736,
         "gp:id":24551353,
         "hasc:id":"-99",
+        "iso:code":"MT-37",
+        "qs:local_id":"2643",
         "unlc:id":"MT-37",
         "wd:id":"Q929969"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"b64b4bf56eed1df9a9fe5976aa944c92",
+    "wof:geomhash":"41630e4e5e9d1377b30cefcc5ea9464b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -279,7 +285,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846220,
+    "wof:lastmodified":1695884323,
     "wof:name":"Nadur",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/870/03/85687003.geojson
+++ b/data/856/870/03/85687003.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":4301,
     "eurostat:population_year":2020,
     "geom:area":0.000764,
-    "geom:area_square_m":7640371.458159,
+    "geom:area_square_m":7640358.928306,
     "geom:bbox":"14.249259,36.038278,14.286077,36.073365",
     "geom:latitude":36.053596,
     "geom:longitude":14.267244,
@@ -34,7 +34,7 @@
     "mps:latitude":36.053524,
     "mps:longitude":14.267244,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -273,11 +273,17 @@
         "gn:id":8299759,
         "gp:id":24551356,
         "hasc:id":"-99",
+        "iso:code":"MT-61",
+        "qs:local_id":"2663",
         "unlc:id":"MT-61",
         "wd:id":"Q605343"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"6b73994cae4d61fcca50e3cd7986c50d",
+    "wof:geomhash":"bf592bb21f63d810622aee46fd13a1c5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -294,7 +300,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846225,
+    "wof:lastmodified":1695884323,
     "wof:name":"Xaghra",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/870/07/85687007.geojson
+++ b/data/856/870/07/85687007.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.067533,
     "mps:longitude":14.201227,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -134,8 +134,14 @@
         "gn:id":8299711,
         "gp:id":24551351,
         "hasc:id":"-99",
+        "iso:code":"MT-14",
+        "qs:local_id":"2623",
         "unlc:id":"MT-14"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"0dc3462987442c93d226d2fc98a62459",
     "wof:hierarchy":[
@@ -154,7 +160,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"Gharb",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/870/13/85687013.geojson
+++ b/data/856/870/13/85687013.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":422,
     "eurostat:population_year":2020,
     "geom:area":0.000506,
-    "geom:area_square_m":5059593.431388,
+    "geom:area_square_m":5059586.570675,
     "geom:bbox":"14.209361,36.050252,14.237581,36.082288",
     "geom:latitude":36.066599,
     "geom:longitude":14.2227,
@@ -34,7 +34,7 @@
     "mps:latitude":36.070998,
     "mps:longitude":14.220135,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -267,11 +267,17 @@
         "gn:id":8299713,
         "gp:id":24551355,
         "hasc:id":"-99",
+        "iso:code":"MT-16",
+        "qs:local_id":"2625",
         "unlc:id":"MT-16",
         "wd:id":"Q1017339"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"5774d5c65d9176d4742bb7fd811060ca",
+    "wof:geomhash":"ecd2c94378bf8d247fbd8438202eb56a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -288,7 +294,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1690846225,
+    "wof:lastmodified":1695884323,
     "wof:name":"Ghasri",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/870/17/85687017.geojson
+++ b/data/856/870/17/85687017.geojson
@@ -34,7 +34,7 @@
     "mps:latitude":36.068135,
     "mps:longitude":14.244979,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -64,8 +64,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"MT_MT02666",
-        "eurostat:nuts_2021_id":"MT02666"
+        "eurostat:nuts_2021_id":"MT02666",
+        "iso:code":"MT-65",
+        "qs:local_id":"2666"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
     "wof:geomhash":"7c46d1d284e3e9c96ad06c4ad7bfa1f6",
     "wof:hierarchy":[
@@ -84,7 +90,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1684354005,
+    "wof:lastmodified":1695884323,
     "wof:name":"Zebbug (Ghawdex)",
     "wof:parent_id":85633331,
     "wof:placetype":"region",

--- a/data/856/870/31/85687031.geojson
+++ b/data/856/870/31/85687031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
-    "geom:area_square_m":4987.253344,
+    "geom:area_square_m":4991.515564,
     "geom:bbox":"14.324167,36.010644,14.325774,36.011338",
     "geom:latitude":36.01091,
     "geom:longitude":14.324866,
@@ -22,7 +22,7 @@
     "mps:latitude":36.01097,
     "mps:longitude":14.32472,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -48,9 +48,16 @@
         85633331
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"MT-13",
+        "qs:local_id":"2622"
+    },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"MT",
-    "wof:geomhash":"7a15fb5edad76794ef593e29d30b83a0",
+    "wof:geomhash":"30fadceccb3e213665081172276b1317",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -67,7 +74,7 @@
         "mlt",
         "eng"
     ],
-    "wof:lastmodified":1627522383,
+    "wof:lastmodified":1695884284,
     "wof:name":"Ghajnsielem u Kemmuna",
     "wof:parent_id":85633331,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.